### PR TITLE
feat: add collapse-diff option to control diff comment expansion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,12 @@ inputs:
       The name property of the job, to correctly link to the action/job logs when generating the summaries.
       Optional for `mode: generate`
     required: false
+  collapse-diff:
+    description: |
+      Whether to collapse the diff details in the PR description by default.
+      Optional for `mode: print`.
+      Defaults to 'false'.
+    required: false
   diff-rules:
     description: |
       An array of objects indicating rules to apply to the diff output on the PR description.

--- a/src/main/print.ts
+++ b/src/main/print.ts
@@ -49,9 +49,12 @@ export async function print(prContext: PrContext) {
     });
   }
 
+  const collapseDiffInput = core.getInput('collapse-diff', { required: false });
+  const diffCollapsed = collapseDiffInput.toLowerCase() === 'true';
+
   const { owner, repo, pullNumber, gitHash, githubToken } = prContext;
   await restoreCaches(githubToken, assemblyDiffs, pullNumber);
-  await commentOnPr(githubToken, assemblyDiffs, owner, repo, pullNumber, gitHash);
+  await commentOnPr(githubToken, assemblyDiffs, owner, repo, pullNumber, gitHash, diffCollapsed);
 }
 
 async function listCachesWithPrefix(token: string, prefix: string, pullNumber: number) {
@@ -133,7 +136,8 @@ async function commentOnPr(
   owner: string,
   repo: string,
   pullNumber: number,
-  gitHash: string
+  gitHash: string,
+  diffCollapsed: boolean
 ) {
   const diffs: AssemblyDiff[] = [];
   for (const assemblyDiff of assemblyDiffs) {
@@ -173,5 +177,5 @@ async function commentOnPr(
     core.info(markdown);
   }
 
-  await updateGithubPrDescription(owner, repo, pullNumber, githubToken, diffs, gitHash);
+  await updateGithubPrDescription(owner, repo, pullNumber, githubToken, diffs, gitHash, diffCollapsed);
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -88,7 +88,8 @@ export async function updateGithubPrDescription(
   pullNumber: number,
   ghToken: string,
   diffs: AssemblyDiff[],
-  gitHash: string
+  gitHash: string,
+  diffCollapsed: boolean = false
 ) {
   const MyOctokit = Octokit.plugin(restEndpointMethods);
   const octokit = new MyOctokit({ auth: ghToken });
@@ -112,7 +113,7 @@ export async function updateGithubPrDescription(
     newContent += `
 ## ${diff.header}
 
-<details open>
+<details${diffCollapsed ? '' : ' open'}>
 <summary> Details ${summaryText} </summary>
 
 ${diff.markdown}


### PR DESCRIPTION
- Added collapse-diff input to `action.yml` for `mode: print`, defaulting to false (expanded)
- Reads the input in `print.ts` and passes it through as d`iffCollapsed` to `updateGithubPrDescription`
- In `output.ts`, uses the HTML open attribute on `<details>` to toggle expansion — `<details>` when collapsed, `<details open>` when expanded — keeping a single template with no duplication

### Usage
```yaml
  - uses: rehanvdm/cdk-express-pipeline-github-diff@v1
    with:
      mode: print
      collapse-diff: true  # opt in to collapsed; default is expanded
      github-token: ${{ secrets.GITHUB_TOKEN }}
```